### PR TITLE
Add card stacks and basic card drawing support

### DIFF
--- a/src/main/kotlin/com/tylerkindy/betrayal/db/cardStacks.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/cardStacks.kt
@@ -1,8 +1,6 @@
 package com.tylerkindy.betrayal.db
 
-import com.tylerkindy.betrayal.EventCard
-import com.tylerkindy.betrayal.ItemCard
-import com.tylerkindy.betrayal.OmenCard
+import com.tylerkindy.betrayal.Card
 import com.tylerkindy.betrayal.defs.CardType
 import com.tylerkindy.betrayal.defs.events
 import com.tylerkindy.betrayal.defs.items
@@ -61,48 +59,27 @@ private fun createCardStack(gameId: String, cardType: CardType, contents: List<C
     }
 }
 
-fun drawItem(gameId: String): ItemCard {
+fun drawItem(gameId: String): Card.ItemCard {
     return drawCard(gameId, CardType.ITEM) {
         val cardDefId = this[CardStackContents.cardDefId]
         val cardDef = items[cardDefId] ?: error("No item def with ID $cardDefId")
-        ItemCard(
-            id = this[CardStackContents.id],
-            name = cardDef.name,
-            subtype = cardDef.subtype,
-            flavorText = cardDef.flavorText,
-            description = cardDef.description,
-            rollTable = cardDef.rollTable
-        )
+        cardDef.toCard()
     }
 }
 
-fun drawEvent(gameId: String): EventCard {
+fun drawEvent(gameId: String): Card.EventCard {
     return drawCard(gameId, CardType.EVENT) {
         val cardDefId = this[CardStackContents.cardDefId]
         val cardDef = events[cardDefId] ?: error("No event def with ID $cardDefId")
-        EventCard(
-            id = this[CardStackContents.id],
-            name = cardDef.name,
-            condition = cardDef.condition,
-            flavorText = cardDef.flavorText,
-            description = cardDef.description,
-            rollTable = cardDef.rollTable
-        )
+        cardDef.toCard()
     }
 }
 
-fun drawOmen(gameId: String): OmenCard {
+fun drawOmen(gameId: String): Card.OmenCard {
     return drawCard(gameId, CardType.OMEN) {
         val cardDefId = this[CardStackContents.cardDefId]
         val cardDef = omens[cardDefId] ?: error("No omen def with ID $cardDefId")
-        OmenCard(
-            id = this[CardStackContents.id],
-            name = cardDef.name,
-            subtype = cardDef.subtype,
-            flavorText = cardDef.flavorText,
-            description = cardDef.description,
-            rollTable = cardDef.rollTable
-        )
+        cardDef.toCard()
     }
 }
 

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/cardStacks.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/cardStacks.kt
@@ -1,0 +1,58 @@
+package com.tylerkindy.betrayal.db
+
+import com.tylerkindy.betrayal.defs.CardType
+import com.tylerkindy.betrayal.defs.events
+import com.tylerkindy.betrayal.defs.items
+import com.tylerkindy.betrayal.defs.omens
+import org.jetbrains.exposed.sql.batchInsert
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
+
+fun createCardStacks(gameId: String) {
+    val itemStackContents = items.shuffled()
+        .mapIndexed { i, item ->
+            CardStackContentRequest(
+                index = i.toShort(),
+                cardDefId = item.id
+            )
+        }
+    val eventStackContents = events.shuffled()
+        .mapIndexed { i, event ->
+            CardStackContentRequest(
+                index = i.toShort(),
+                cardDefId = event.id
+            )
+        }
+    val omenStackContents = omens.shuffled()
+        .mapIndexed { i, omen ->
+            CardStackContentRequest(
+                index = i.toShort(),
+                cardDefId = omen.id
+            )
+        }
+
+    transaction {
+        createCardStack(gameId, CardType.ITEM, itemStackContents)
+        createCardStack(gameId, CardType.EVENT, eventStackContents)
+        createCardStack(gameId, CardType.OMEN, omenStackContents)
+    }
+}
+
+fun createCardStack(gameId: String, cardType: CardType, contents: List<CardStackContentRequest>) {
+    val stackId = CardStacks.insert {
+        it[this.gameId] = gameId
+        it[cardTypeId] = cardType.id
+        it[curIndex] = 0
+    } get CardStacks.id
+
+    CardStackContents.batchInsert(contents) {
+        this[CardStackContents.stackId] = stackId
+        this[CardStackContents.index] = it.index
+        this[CardStackContents.cardDefId] = it.cardDefId
+    }
+}
+
+data class CardStackContentRequest(
+    val index: Short,
+    val cardDefId: Short
+)

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/cardStacks.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/cardStacks.kt
@@ -2,6 +2,7 @@ package com.tylerkindy.betrayal.db
 
 import com.tylerkindy.betrayal.EventCard
 import com.tylerkindy.betrayal.ItemCard
+import com.tylerkindy.betrayal.OmenCard
 import com.tylerkindy.betrayal.defs.CardType
 import com.tylerkindy.betrayal.defs.events
 import com.tylerkindy.betrayal.defs.items
@@ -83,6 +84,21 @@ fun drawEvent(gameId: String): EventCard {
             id = this[CardStackContents.id],
             name = cardDef.name,
             condition = cardDef.condition,
+            flavorText = cardDef.flavorText,
+            description = cardDef.description,
+            rollTable = cardDef.rollTable
+        )
+    }
+}
+
+fun drawOmen(gameId: String): OmenCard {
+    return drawCard(gameId, CardType.OMEN) {
+        val cardDefId = this[CardStackContents.cardDefId]
+        val cardDef = omens[cardDefId] ?: error("No omen def with ID $cardDefId")
+        OmenCard(
+            id = this[CardStackContents.id],
+            name = cardDef.name,
+            subtype = cardDef.subtype,
             flavorText = cardDef.flavorText,
             description = cardDef.description,
             rollTable = cardDef.rollTable

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/cardStacks.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/cardStacks.kt
@@ -1,5 +1,6 @@
 package com.tylerkindy.betrayal.db
 
+import com.tylerkindy.betrayal.EventCard
 import com.tylerkindy.betrayal.ItemCard
 import com.tylerkindy.betrayal.defs.CardType
 import com.tylerkindy.betrayal.defs.events
@@ -67,6 +68,21 @@ fun drawItem(gameId: String): ItemCard {
             id = this[CardStackContents.id],
             name = cardDef.name,
             subtype = cardDef.subtype,
+            flavorText = cardDef.flavorText,
+            description = cardDef.description,
+            rollTable = cardDef.rollTable
+        )
+    }
+}
+
+fun drawEvent(gameId: String): EventCard {
+    return drawCard(gameId, CardType.EVENT) {
+        val cardDefId = this[CardStackContents.cardDefId]
+        val cardDef = events[cardDefId] ?: error("No event def with ID $cardDefId")
+        EventCard(
+            id = this[CardStackContents.id],
+            name = cardDef.name,
+            condition = cardDef.condition,
             flavorText = cardDef.flavorText,
             description = cardDef.description,
             rollTable = cardDef.rollTable

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/cardStacks.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/cardStacks.kt
@@ -158,7 +158,7 @@ private fun ResultRow.toCardStack(): CardStack {
     return CardStack(
         id = this[CardStacks.id],
         gameId = this[CardStacks.gameId],
-        cardType = CardType.values().first { it.id == this[CardStacks.cardTypeId] },
+        cardType = CardType.fromId(this[CardStacks.cardTypeId]),
         curIndex = this[CardStacks.curIndex]
     )
 }

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/drawnCards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/drawnCards.kt
@@ -1,0 +1,29 @@
+package com.tylerkindy.betrayal.db
+
+import com.tylerkindy.betrayal.Card
+import com.tylerkindy.betrayal.defs.CardType
+import com.tylerkindy.betrayal.defs.events
+import com.tylerkindy.betrayal.defs.items
+import com.tylerkindy.betrayal.defs.omens
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.select
+import org.jetbrains.exposed.sql.transactions.transaction
+
+fun getDrawnCard(gameId: String): Card {
+    return transaction {
+        val row = DrawnCards.select { DrawnCards.gameId eq gameId }
+            .firstOrNull() ?: throw IllegalStateException("No drawn card")
+
+        when (CardType.fromId(row[DrawnCards.cardTypeId])) {
+            CardType.EVENT -> events[row[DrawnCards.cardDefId]]!!.toCard()
+            CardType.ITEM -> items[row[DrawnCards.cardDefId]]!!.toCard()
+            CardType.OMEN -> omens[row[DrawnCards.cardDefId]]!!.toCard()
+        }
+    }
+}
+
+fun discardDrawnCard(gameId: String) {
+    transaction {
+        DrawnCards.deleteWhere { DrawnCards.gameId eq gameId }
+    }
+}

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/tables.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/tables.kt
@@ -46,3 +46,17 @@ object RoomStackContents : Table("\"roomStackContents\"") {
     val index = short("index")
     val roomDefId = short("roomDefId")
 }
+
+object CardStacks : Table("\"cardStacks\"") {
+    val id = integer("id").autoIncrement(idSeqName = "cardStacks_id_seq")
+    val gameId = varchar("gameId", 6)
+    val cardTypeId = short("cardTypeId")
+    val curIndex = short("curIndex").nullable()
+}
+
+object CardStackContents : Table("\"cardStackContents\"") {
+    val id = integer("id").autoIncrement(idSeqName = "cardStackContents_id_seq")
+    val stackId = integer("stackId")
+    val index = short("index")
+    val cardDefId = short("cardDefId")
+}

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/tables.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/tables.kt
@@ -60,3 +60,10 @@ object CardStackContents : Table("\"cardStackContents\"") {
     val index = short("index")
     val cardDefId = short("cardDefId")
 }
+
+object DrawnCards : Table("\"drawnCards\"") {
+    val id = integer("id").autoIncrement(idSeqName = "drawnCards_id_seq")
+    val gameId = integer("gameId")
+    val cardTypeId = short("cardTypeId")
+    val cardDefId = short("cardDefId")
+}

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/tables.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/tables.kt
@@ -63,7 +63,7 @@ object CardStackContents : Table("\"cardStackContents\"") {
 
 object DrawnCards : Table("\"drawnCards\"") {
     val id = integer("id").autoIncrement(idSeqName = "drawnCards_id_seq")
-    val gameId = integer("gameId")
+    val gameId = varchar("gameId", 6)
     val cardTypeId = short("cardTypeId")
     val cardDefId = short("cardDefId")
 }

--- a/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
@@ -175,5 +175,11 @@ val omens = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
 enum class CardType(val id: Short) {
     EVENT(0),
     ITEM(1),
-    OMEN(2)
+    OMEN(2);
+
+    companion object {
+        fun fromId(id: Short): CardType {
+            return values().first { it.id == id }
+        }
+    }
 }

--- a/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
@@ -144,6 +144,7 @@ val events = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
             rollTable = parseRollTable(it["rollTable"])
         )
     }
+    .associateBy { it.id }
 val items = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
     .parse(InputStreamReader(ItemDefinition::class.java.getResourceAsStream("/items.csv")))
     .map {
@@ -156,6 +157,7 @@ val items = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
             rollTable = parseRollTable(it["rollTable"])
         )
     }
+    .associateBy { it.id }
 val omens = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
     .parse(InputStreamReader(OmenDefinition::class.java.getResourceAsStream("/omens.csv")))
     .map {
@@ -168,6 +170,7 @@ val omens = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
             rollTable = parseRollTable(it["rollTable"])
         )
     }
+    .associateBy { it.id }
 
 enum class CardType(val id: Short) {
     EVENT(0),

--- a/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
@@ -1,0 +1,135 @@
+package com.tylerkindy.betrayal.defs
+
+import org.apache.commons.csv.CSVFormat
+import java.io.InputStreamReader
+
+sealed class RollTarget {
+    data class ExactRollTarget(val target: Int) : RollTarget() {
+        override fun matches(roll: Int): Boolean {
+            return target == roll
+        }
+    }
+
+    data class RangeRollTarget(val target: IntRange) : RollTarget() {
+        override fun matches(roll: Int): Boolean {
+            return target.contains(roll)
+        }
+    }
+
+    data class MinRollTarget(val minimum: Int) : RollTarget() {
+        override fun matches(roll: Int): Boolean {
+            return roll >= minimum
+        }
+    }
+
+    abstract fun matches(roll: Int): Boolean
+
+    companion object {
+        private val EXACT_REGEX = Regex("(\\d+)")
+        private val RANGE_REGEX = Regex("(\\d+)-(\\d+)")
+        private val MIN_REGEX = Regex("(\\d+)\\+")
+
+        fun parse(s: String): RollTarget {
+            return EXACT_REGEX.matchEntire(s)
+                ?.let { ExactRollTarget(it.groupValues[1].toInt()) }
+                ?: RANGE_REGEX.matchEntire(s)
+                    ?.let {
+                        RangeRollTarget(
+                            IntRange(
+                                it.groupValues[1].toInt(),
+                                it.groupValues[2].toInt()
+                            )
+                        )
+                    }
+                ?: MIN_REGEX.matchEntire(s)
+                    ?.let { MinRollTarget(it.groupValues[1].toInt()) }
+                ?: throw IllegalArgumentException("Invalid roll target: '$s'")
+        }
+    }
+}
+
+data class RollTableRow(
+    val target: RollTarget,
+    val outcome: String
+)
+typealias RollTable = List<RollTableRow>
+
+private val ROW_REGEX = Regex("([^\\s]+) {2}(.*)")
+fun parseRollTable(s: String?): RollTable? {
+    return s?.split('\n')
+        ?.map { ROW_REGEX.matchEntire(it) ?: throw IllegalArgumentException("Invalid row '$it'") }
+        ?.map {
+            RollTableRow(
+                target = RollTarget.parse(it.groupValues[1]),
+                outcome = it.groupValues[2]
+            )
+        }
+}
+
+data class EventDefinition(
+    val id: Short,
+    val name: String,
+    val condition: String?,
+    val flavorText: String?,
+    val description: String,
+    val rollTable: RollTable?
+)
+
+enum class Subtype {
+    COMPANION, WEAPON
+}
+
+data class ItemDefinition(
+    val id: Short,
+    val name: String,
+    val subtype: Subtype?,
+    val flavorText: String?,
+    val description: String,
+    val rollTable: RollTable?
+)
+
+data class OmenDefinition(
+    val id: Short,
+    val name: String,
+    val subtype: Subtype?,
+    val flavorText: String?,
+    val description: String,
+    val rollTable: RollTable?
+)
+
+val events = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
+    .parse(InputStreamReader(EventDefinition::class.java.getResourceAsStream("/events.csv")))
+    .map {
+        EventDefinition(
+            id = it["id"].toShort(),
+            name = it["name"],
+            condition = it["condition"],
+            flavorText = it["flavorText"],
+            description = it["description"],
+            rollTable = parseRollTable(it["rollTable"])
+        )
+    }
+val items = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
+    .parse(InputStreamReader(ItemDefinition::class.java.getResourceAsStream("/items.csv")))
+    .map {
+        ItemDefinition(
+            id = it["id"].toShort(),
+            name = it["name"],
+            subtype = it["subtype"]?.let(Subtype::valueOf),
+            flavorText = it["flavorText"],
+            description = it["description"],
+            rollTable = parseRollTable(it["rollTable"])
+        )
+    }
+val omens = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
+    .parse(InputStreamReader(OmenDefinition::class.java.getResourceAsStream("/omens.csv")))
+    .map {
+        OmenDefinition(
+            id = it["id"].toShort(),
+            name = it["name"],
+            subtype = it["subtype"]?.let(Subtype::valueOf),
+            flavorText = it["flavorText"],
+            description = it["description"],
+            rollTable = parseRollTable(it["rollTable"])
+        )
+    }

--- a/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
@@ -1,5 +1,6 @@
 package com.tylerkindy.betrayal.defs
 
+import com.tylerkindy.betrayal.Card
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -107,7 +108,17 @@ data class EventDefinition(
     val flavorText: String?,
     val description: String,
     val rollTable: RollTable?
-)
+) {
+    fun toCard(): Card.EventCard {
+        return Card.EventCard(
+            name = name,
+            condition = condition,
+            flavorText = flavorText,
+            description = description,
+            rollTable = rollTable
+        )
+    }
+}
 
 @Serializable
 enum class Subtype {
@@ -121,7 +132,17 @@ data class ItemDefinition(
     val flavorText: String?,
     val description: String,
     val rollTable: RollTable?
-)
+) {
+    fun toCard(): Card.ItemCard {
+        return Card.ItemCard(
+            name = name,
+            subtype = subtype,
+            flavorText = flavorText,
+            description = description,
+            rollTable = rollTable
+        )
+    }
+}
 
 data class OmenDefinition(
     val id: Short,
@@ -130,7 +151,17 @@ data class OmenDefinition(
     val flavorText: String?,
     val description: String,
     val rollTable: RollTable?
-)
+) {
+    fun toCard(): Card.OmenCard {
+        return Card.OmenCard(
+            name = name,
+            subtype = subtype,
+            flavorText = flavorText,
+            description = description,
+            rollTable = rollTable
+        )
+    }
+}
 
 val events = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
     .parse(InputStreamReader(EventDefinition::class.java.getResourceAsStream("/events.csv")))

--- a/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
@@ -133,3 +133,9 @@ val omens = CSVFormat.DEFAULT.withNullString("").withFirstRecordAsHeader()
             rollTable = parseRollTable(it["rollTable"])
         )
     }
+
+enum class CardType(val id: Short) {
+    EVENT(0),
+    ITEM(1),
+    OMEN(2)
+}

--- a/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/defs/cards.kt
@@ -81,6 +81,7 @@ sealed class RollTarget {
     }
 }
 
+@Serializable
 data class RollTableRow(
     val target: RollTarget,
     val outcome: String
@@ -108,6 +109,7 @@ data class EventDefinition(
     val rollTable: RollTable?
 )
 
+@Serializable
 enum class Subtype {
     COMPANION, WEAPON
 }

--- a/src/main/kotlin/com/tylerkindy/betrayal/models.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/models.kt
@@ -143,6 +143,16 @@ data class ItemCard(
 )
 
 @Serializable
+data class EventCard(
+    val id: Int,
+    val name: String,
+    val condition: String?,
+    val flavorText: String?,
+    val description: String,
+    val rollTable: RollTable?
+)
+
+@Serializable
 data class GameRequest(val name: String, val numPlayers: Int)
 
 @Serializable

--- a/src/main/kotlin/com/tylerkindy/betrayal/models.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/models.kt
@@ -2,6 +2,7 @@ package com.tylerkindy.betrayal
 
 import com.tylerkindy.betrayal.defs.RollTable
 import com.tylerkindy.betrayal.defs.Subtype
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Suppress("unused")
@@ -133,34 +134,37 @@ data class PlaceRoomResponse(
 )
 
 @Serializable
-data class ItemCard(
-    val id: Int,
-    val name: String,
-    val subtype: Subtype?,
-    val flavorText: String?,
-    val description: String,
-    val rollTable: RollTable?
-)
+sealed class Card {
+    @Serializable
+    @SerialName("ITEM")
+    data class ItemCard(
+        val name: String,
+        val subtype: Subtype?,
+        val flavorText: String?,
+        val description: String,
+        val rollTable: RollTable?
+    )
 
-@Serializable
-data class EventCard(
-    val id: Int,
-    val name: String,
-    val condition: String?,
-    val flavorText: String?,
-    val description: String,
-    val rollTable: RollTable?
-)
+    @Serializable
+    @SerialName("EVENT")
+    data class EventCard(
+        val name: String,
+        val condition: String?,
+        val flavorText: String?,
+        val description: String,
+        val rollTable: RollTable?
+    )
 
-@Serializable
-data class OmenCard(
-    val id: Int,
-    val name: String,
-    val subtype: Subtype?,
-    val flavorText: String?,
-    val description: String,
-    val rollTable: RollTable?
-)
+    @Serializable
+    @SerialName("OMEN")
+    data class OmenCard(
+        val name: String,
+        val subtype: Subtype?,
+        val flavorText: String?,
+        val description: String,
+        val rollTable: RollTable?
+    )
+}
 
 @Serializable
 data class GameRequest(val name: String, val numPlayers: Int)

--- a/src/main/kotlin/com/tylerkindy/betrayal/models.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/models.kt
@@ -1,5 +1,7 @@
 package com.tylerkindy.betrayal
 
+import com.tylerkindy.betrayal.defs.RollTable
+import com.tylerkindy.betrayal.defs.Subtype
 import kotlinx.serialization.Serializable
 
 @Suppress("unused")
@@ -128,6 +130,16 @@ data class RoomStackResponse(
 data class PlaceRoomResponse(
     val rooms: List<Room>,
     val nextRoom: StackRoom?
+)
+
+@Serializable
+data class ItemCard(
+    val id: Int,
+    val name: String,
+    val subtype: Subtype?,
+    val flavorText: String?,
+    val description: String,
+    val rollTable: RollTable?
 )
 
 @Serializable

--- a/src/main/kotlin/com/tylerkindy/betrayal/models.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/models.kt
@@ -143,7 +143,7 @@ sealed class Card {
         val flavorText: String?,
         val description: String,
         val rollTable: RollTable?
-    )
+    ) : Card()
 
     @Serializable
     @SerialName("EVENT")
@@ -153,7 +153,7 @@ sealed class Card {
         val flavorText: String?,
         val description: String,
         val rollTable: RollTable?
-    )
+    ) : Card()
 
     @Serializable
     @SerialName("OMEN")
@@ -163,7 +163,7 @@ sealed class Card {
         val flavorText: String?,
         val description: String,
         val rollTable: RollTable?
-    )
+    ) : Card()
 }
 
 @Serializable

--- a/src/main/kotlin/com/tylerkindy/betrayal/models.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/models.kt
@@ -153,6 +153,16 @@ data class EventCard(
 )
 
 @Serializable
+data class OmenCard(
+    val id: Int,
+    val name: String,
+    val subtype: Subtype?,
+    val flavorText: String?,
+    val description: String,
+    val rollTable: RollTable?
+)
+
+@Serializable
 data class GameRequest(val name: String, val numPlayers: Int)
 
 @Serializable

--- a/src/main/kotlin/com/tylerkindy/betrayal/routes/cards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/routes/cards.kt
@@ -1,5 +1,6 @@
 package com.tylerkindy.betrayal.routes
 
+import com.tylerkindy.betrayal.db.drawEvent
 import com.tylerkindy.betrayal.db.drawItem
 import io.ktor.application.call
 import io.ktor.response.respond
@@ -13,6 +14,13 @@ val cardRoutes: Route.() -> Unit = {
             post("draw") {
                 val gameId = call.parameters["gameId"]!!
                 call.respond(drawItem(gameId))
+            }
+        }
+
+        route("events") {
+            post("draw") {
+                val gameId = call.parameters["gameId"]!!
+                call.respond(drawEvent(gameId))
             }
         }
     }

--- a/src/main/kotlin/com/tylerkindy/betrayal/routes/cards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/routes/cards.kt
@@ -1,35 +1,71 @@
 package com.tylerkindy.betrayal.routes
 
+import com.tylerkindy.betrayal.Card
+import com.tylerkindy.betrayal.db.discardDrawnCard
 import com.tylerkindy.betrayal.db.drawEvent
 import com.tylerkindy.betrayal.db.drawItem
 import com.tylerkindy.betrayal.db.drawOmen
+import com.tylerkindy.betrayal.db.getDrawnCard
+import io.ktor.application.ApplicationCall
 import io.ktor.application.call
+import io.ktor.content.TextContent
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.response.respond
 import io.ktor.routing.Route
+import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.route
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 val cardRoutes: Route.() -> Unit = {
     route("cards") {
         route("items") {
             post("draw") {
                 val gameId = call.parameters["gameId"]!!
-                call.respond(drawItem(gameId))
+                call.respondWithCard(drawItem(gameId))
             }
         }
 
         route("events") {
             post("draw") {
                 val gameId = call.parameters["gameId"]!!
-                call.respond(drawEvent(gameId))
+                call.respondWithCard(drawEvent(gameId))
             }
         }
 
         route("omens") {
             post("draw") {
                 val gameId = call.parameters["gameId"]!!
-                call.respond(drawOmen(gameId))
+                call.respondWithCard(drawOmen(gameId))
+            }
+        }
+
+        route("drawn") {
+            get {
+                val gameId = call.parameters["gameId"]!!
+                val card: Card = getDrawnCard(gameId)
+                call.respondWithCard(card)
+            }
+            post("discard") {
+                val gameId = call.parameters["gameId"]!!
+                discardDrawnCard(gameId)
+                call.respond(HttpStatusCode.OK, "")
             }
         }
     }
+}
+
+// Workaround because of ktor top-level serialization bug
+// https://github.com/ktorio/ktor/issues/1783#issuecomment-727645523
+suspend inline fun ApplicationCall.respondWithCard(card: Card) {
+    response.pipeline.execute(
+        this,
+        TextContent(
+            text = Json.encodeToString(card),
+            ContentType.Application.Json,
+            HttpStatusCode.OK
+        )
+    )
 }

--- a/src/main/kotlin/com/tylerkindy/betrayal/routes/cards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/routes/cards.kt
@@ -1,0 +1,19 @@
+package com.tylerkindy.betrayal.routes
+
+import com.tylerkindy.betrayal.db.drawItem
+import io.ktor.application.call
+import io.ktor.response.respond
+import io.ktor.routing.Route
+import io.ktor.routing.post
+import io.ktor.routing.route
+
+val cardRoutes: Route.() -> Unit = {
+    route("cards") {
+        route("items") {
+            post("draw") {
+                val gameId = call.parameters["gameId"]!!
+                call.respond(drawItem(gameId))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/tylerkindy/betrayal/routes/cards.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/routes/cards.kt
@@ -2,6 +2,7 @@ package com.tylerkindy.betrayal.routes
 
 import com.tylerkindy.betrayal.db.drawEvent
 import com.tylerkindy.betrayal.db.drawItem
+import com.tylerkindy.betrayal.db.drawOmen
 import io.ktor.application.call
 import io.ktor.response.respond
 import io.ktor.routing.Route
@@ -21,6 +22,13 @@ val cardRoutes: Route.() -> Unit = {
             post("draw") {
                 val gameId = call.parameters["gameId"]!!
                 call.respond(drawEvent(gameId))
+            }
+        }
+
+        route("omens") {
+            post("draw") {
+                val gameId = call.parameters["gameId"]!!
+                call.respond(drawOmen(gameId))
             }
         }
     }

--- a/src/main/kotlin/com/tylerkindy/betrayal/routes/games.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/routes/games.kt
@@ -37,6 +37,7 @@ val gameRoutes: Routing.() -> Unit = {
             roomRoutes()
             playerRoutes()
             roomStackRoutes()
+            cardRoutes()
         }
 
         post {

--- a/src/main/kotlin/com/tylerkindy/betrayal/routes/games.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/routes/games.kt
@@ -3,6 +3,7 @@ package com.tylerkindy.betrayal.routes
 import com.tylerkindy.betrayal.Game
 import com.tylerkindy.betrayal.GameRequest
 import com.tylerkindy.betrayal.db.Games
+import com.tylerkindy.betrayal.db.createCardStacks
 import com.tylerkindy.betrayal.db.createRoomStack
 import com.tylerkindy.betrayal.db.insertStartingPlayers
 import com.tylerkindy.betrayal.db.insertStartingRooms
@@ -61,6 +62,7 @@ val gameRoutes: Routing.() -> Unit = {
             insertStartingRooms(gameId)
             insertStartingPlayers(gameId, gameRequest.numPlayers)
             createRoomStack(gameId)
+            createCardStacks(gameId)
 
             call.respond(Game(id = gameId, name = gameRequest.name))
         }

--- a/src/main/kotlin/com/tylerkindy/betrayal/server.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/server.kt
@@ -7,7 +7,6 @@ import io.ktor.features.CORS
 import io.ktor.features.CallLogging
 import io.ktor.features.ContentNegotiation
 import io.ktor.routing.routing
-import io.ktor.serialization.DefaultJson
 import io.ktor.serialization.json
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
@@ -26,8 +25,9 @@ fun main() {
     embeddedServer(Netty, port = port) {
         install(ContentNegotiation) {
             json(
-                Json(DefaultJson) {
-                    prettyPrint = true
+                Json {
+                    encodeDefaults = true
+                    isLenient = true
                 }
             )
         }

--- a/src/main/resources/events.csv
+++ b/src/main/resources/events.csv
@@ -208,4 +208,4 @@ Choose one of your item cards (not an omen card) and put it on the item stack. T
 <rollTable>","0-1  You sign your soul away for nothing. Lose 1 Sanity.
 2-3  You lose your soul but you gain power. Lose 1 Sanity. Draw an item card.
 4  You find a small loophole and keep your soul. Draw an item card.
-5+ You find the contract isn’t binding and keep your soul. Gain 1 Sanity. Draw an item card."
+5+  You find the contract isn’t binding and keep your soul. Gain 1 Sanity. Draw an item card."

--- a/src/main/resources/migrations.sql
+++ b/src/main/resources/migrations.sql
@@ -69,3 +69,13 @@ CREATE TABLE "cardStackContents" (
 );
 
 CREATE UNIQUE INDEX ON "cardStackContents" ("stackId", "index")
+
+--changeset tkindy:6
+CREATE TABLE "drawnCards" (
+    "id" SERIAL PRIMARY KEY,
+    "gameId" VARCHAR(6) NOT NULL,
+    "cardTypeId" SMALLINT NOT NULL,
+    "cardDefId" SMALLINT NOT NULL
+);
+
+CREATE UNIQUE INDEX ON "drawnCards" ("gameId");

--- a/src/main/resources/migrations.sql
+++ b/src/main/resources/migrations.sql
@@ -50,3 +50,22 @@ CREATE TABLE "roomStackContents" (
     "index" SMALLINT NOT NULL,
     "roomDefId" SMALLINT NOT NULL
 );
+
+--changeset tkindy:5
+CREATE TABLE "cardStacks" (
+    "id" SERIAL PRIMARY KEY,
+    "gameId" VARCHAR(6) NOT NULL,
+    "cardTypeId" SMALLINT NOT NULL,
+    "curIndex" SMALLINT
+);
+
+CREATE UNIQUE INDEX ON "cardStacks" ("gameId", "cardTypeId");
+
+CREATE TABLE "cardStackContents" (
+    "id" SERIAL PRIMARY KEY,
+    "stackId" INT NOT NULL,
+    "index" SMALLINT NOT NULL,
+    "cardDefId" SMALLINT NOT NULL
+);
+
+CREATE UNIQUE INDEX ON "cardStackContents" ("stackId", "index")

--- a/src/test/kotlin/com/tylerkindy/betrayal/defs/CardsKtTest.kt
+++ b/src/test/kotlin/com/tylerkindy/betrayal/defs/CardsKtTest.kt
@@ -1,0 +1,46 @@
+package com.tylerkindy.betrayal.defs
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class CardsKtTest : StringSpec({
+    "parsing of RangeRollTargets" {
+        val target = RollTarget.parse("3-5")
+
+        target shouldBe RollTarget.RangeRollTarget(3..5)
+        target.matches(2) shouldBe false
+        target.matches(3) shouldBe true
+        target.matches(4) shouldBe true
+        target.matches(5) shouldBe true
+        target.matches(6) shouldBe false
+    }
+
+    "serialization of ExactRollTargets" {
+        val target: RollTarget = RollTarget.ExactRollTarget(7)
+
+        Json.encodeToString(target) shouldBe
+            """
+                {"type":"EXACT","target":7}
+            """.trimIndent()
+    }
+
+    "serialization of RangeRollTargets" {
+        val target: RollTarget = RollTarget.RangeRollTarget(3..5)
+
+        Json.encodeToString(target) shouldBe
+            """
+                {"type":"RANGE","start":3,"end":5}
+            """.trimIndent()
+    }
+
+    "serialization of MinRollTargets" {
+        val target: RollTarget = RollTarget.MinRollTarget(3)
+
+        Json.encodeToString(target) shouldBe
+            """
+                {"type":"MIN","minimum":3}
+            """.trimIndent()
+    }
+})


### PR DESCRIPTION
The card stacks are pretty straightforward.

Each game also has a "drawn card" that will be shown to all players until someone decides to do something with it. Currently, the only thing you can do with it is discard it (which currently just deletes the row from the `drawnCards` table; I might keep a discard list around somewhere in the future). I'm going to implement inventories next, so you'll also be able to send a card to an inventory.