### PR TITLE
Implement placed room movement

### DIFF
--- a/src/main/kotlin/com/tylerkindy/betrayal/db/monsters.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/monsters.kt
@@ -26,7 +26,7 @@ fun getMonsters(gameId: String): List<Monster> {
     }
 }
 
-fun addMonster(gameId: String, loc: GridLoc): Monster {
+fun addMonster(gameId: String): Monster {
     return transaction {
         val prevNumber = Monsters.select { Monsters.gameId eq gameId }
             .orderBy(Monsters.number, SortOrder.DESC)
@@ -34,6 +34,16 @@ fun addMonster(gameId: String, loc: GridLoc): Monster {
             ?.get(Monsters.number)
             ?: 0
         val number = prevNumber + 1
+
+        val loc = Rooms.slice(Rooms.gridX, Rooms.gridY)
+            .select { (Rooms.gameId eq gameId) and (Rooms.roomDefId eq entranceHallDefId ) }
+            .first()
+            .let {
+                GridLoc(
+                    gridX = it[Rooms.gridX],
+                    gridY = it[Rooms.gridY]
+                )
+            }
 
         val id = Monsters.insert {
             it[this.gameId] = gameId

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/monsters.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/monsters.kt
@@ -36,7 +36,7 @@ fun addMonster(gameId: String): Monster {
         val number = prevNumber + 1
 
         val loc = Rooms.slice(Rooms.gridX, Rooms.gridY)
-            .select { (Rooms.gameId eq gameId) and (Rooms.roomDefId eq entranceHallDefId ) }
+            .select { (Rooms.gameId eq gameId) and (Rooms.roomDefId eq entranceHallDefId) }
             .first()
             .let {
                 GridLoc(

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/roomStacks.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/roomStacks.kt
@@ -179,7 +179,7 @@ private fun getNextIndex(stack: RoomStack): Short? {
         ?: remainingIndices.firstOrNull()
 }
 
-private fun rotate(rotation: Short): Short {
+fun rotate(rotation: Short): Short {
     return ((rotation + 3) % 4).toShort()
 }
 

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/rooms.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/rooms.kt
@@ -142,6 +142,20 @@ fun moveRoom(gameId: String, roomId: Int, loc: GridLoc) {
     }
 }
 
+fun rotateRoom(gameId: String, roomId: Int) {
+    transaction {
+        assertRoomInGame(gameId, roomId)
+
+        val curRotation = Rooms.slice(Rooms.rotation)
+            .select { Rooms.id eq roomId }
+            .first()[Rooms.rotation]
+
+        Rooms.update(where = { Rooms.id eq roomId }) {
+            it[rotation] = rotate(curRotation)
+        }
+    }
+}
+
 fun assertRoomInGame(gameId: String, roomId: Int) {
     Rooms.select { (Rooms.id eq roomId) and (Rooms.gameId eq gameId) }
         .firstOrNull()

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/rooms.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/rooms.kt
@@ -40,9 +40,10 @@ private data class StartingRoom(
     val loc: GridLoc
 )
 val entranceHallLoc = GridLoc(4, 3)
+const val entranceHallDefId: Short = 0
 private val startingRooms = listOf(
     // Entrance Hall
-    StartingRoom(0, entranceHallLoc),
+    StartingRoom(entranceHallDefId, entranceHallLoc),
     // Foyer
     StartingRoom(1, GridLoc(3, 3)),
     // Grand Staircase

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/rooms.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/rooms.kt
@@ -9,6 +9,7 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.batchInsert
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
 
 fun ResultRow.toRoom(): Room {
     val roomDefId = this[Rooms.roomDefId]
@@ -94,4 +95,52 @@ fun getRoomAtLoc(gameId: String, loc: GridLoc): Room? {
                 (Rooms.gridY eq loc.gridY)
         }.firstOrNull()?.toRoom()
     }
+}
+
+fun moveRoom(gameId: String, roomId: Int, loc: GridLoc) {
+    transaction {
+        assertRoomInGame(gameId, roomId)
+        if (getRoomAtLoc(gameId, loc) != null) {
+            throw IllegalArgumentException("Can't place room in occupied spot")
+        }
+
+        val originalLoc = Rooms.slice(Rooms.gridX, Rooms.gridY)
+            .select { Rooms.id eq roomId }
+            .first()
+            .let {
+                GridLoc(
+                    gridX = it[Rooms.gridX],
+                    gridY = it[Rooms.gridY]
+                )
+            }
+
+        Rooms.update(where = { Rooms.id eq roomId }) {
+            it[gridX] = loc.gridX
+            it[gridY] = loc.gridY
+        }
+        Players.update(
+            where = {
+                (Players.gameId eq gameId) and
+                    (Players.gridX eq originalLoc.gridX) and
+                    (Players.gridY eq originalLoc.gridY)
+            }
+        ) {
+            it[gridX] = loc.gridX
+            it[gridY] = loc.gridY
+        }
+        Monsters.update(where = {
+            (Monsters.gameId eq gameId) and
+                    (Monsters.gridX eq originalLoc.gridX) and
+                    (Monsters.gridY eq originalLoc.gridY)
+        }) {
+            it[gridX] = loc.gridX
+            it[gridY] = loc.gridY
+        }
+    }
+}
+
+fun assertRoomInGame(gameId: String, roomId: Int) {
+    Rooms.select { (Rooms.id eq roomId) and (Rooms.gameId eq gameId) }
+        .firstOrNull()
+        ?: throw IllegalArgumentException("Room $roomId not in game $gameId")
 }

--- a/src/main/kotlin/com/tylerkindy/betrayal/db/rooms.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/db/rooms.kt
@@ -129,11 +129,13 @@ fun moveRoom(gameId: String, roomId: Int, loc: GridLoc) {
             it[gridX] = loc.gridX
             it[gridY] = loc.gridY
         }
-        Monsters.update(where = {
-            (Monsters.gameId eq gameId) and
+        Monsters.update(
+            where = {
+                (Monsters.gameId eq gameId) and
                     (Monsters.gridX eq originalLoc.gridX) and
                     (Monsters.gridY eq originalLoc.gridY)
-        }) {
+            }
+        ) {
             it[gridX] = loc.gridX
             it[gridY] = loc.gridY
         }

--- a/src/main/kotlin/com/tylerkindy/betrayal/routes/monsters.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/routes/monsters.kt
@@ -2,7 +2,6 @@ package com.tylerkindy.betrayal.routes
 
 import com.tylerkindy.betrayal.GridLoc
 import com.tylerkindy.betrayal.db.addMonster
-import com.tylerkindy.betrayal.db.entranceHallLoc
 import com.tylerkindy.betrayal.db.getMonsters
 import com.tylerkindy.betrayal.db.moveMonster
 import com.tylerkindy.betrayal.sendUpdate
@@ -24,7 +23,7 @@ val monsterRoutes: Route.() -> Unit = {
 
         post {
             val gameId = call.parameters["gameId"]!!
-            call.respond(addMonster(gameId, entranceHallLoc))
+            call.respond(addMonster(gameId))
             sendUpdate(gameId)
         }
 

--- a/src/main/kotlin/com/tylerkindy/betrayal/routes/rooms.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/routes/rooms.kt
@@ -1,10 +1,16 @@
 package com.tylerkindy.betrayal.routes
 
+import com.tylerkindy.betrayal.GridLoc
 import com.tylerkindy.betrayal.db.getRooms
+import com.tylerkindy.betrayal.db.moveRoom
+import com.tylerkindy.betrayal.sendUpdate
 import io.ktor.application.call
+import io.ktor.http.HttpStatusCode
+import io.ktor.request.receiveOrNull
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
+import io.ktor.routing.post
 import io.ktor.routing.route
 
 val roomRoutes: Route.() -> Unit = {
@@ -12,6 +18,20 @@ val roomRoutes: Route.() -> Unit = {
         get {
             val gameId = call.parameters["gameId"]!!
             return@get call.respond(getRooms(gameId))
+        }
+
+        route("{roomId}") {
+            post("move") {
+                val gameId = call.parameters["gameId"]!!
+                val roomId = call.parameters["roomId"]?.toInt()
+                    ?: return@post call.respond(HttpStatusCode.BadRequest, "Invalid room ID")
+                val loc = call.receiveOrNull<GridLoc>()
+                    ?: return@post call.respond(HttpStatusCode.BadRequest, "Missing gridX or gridY")
+
+                moveRoom(gameId, roomId, loc)
+                call.respond(HttpStatusCode.OK, "")
+                sendUpdate(gameId)
+            }
         }
     }
 }

--- a/src/main/kotlin/com/tylerkindy/betrayal/routes/rooms.kt
+++ b/src/main/kotlin/com/tylerkindy/betrayal/routes/rooms.kt
@@ -3,6 +3,7 @@ package com.tylerkindy.betrayal.routes
 import com.tylerkindy.betrayal.GridLoc
 import com.tylerkindy.betrayal.db.getRooms
 import com.tylerkindy.betrayal.db.moveRoom
+import com.tylerkindy.betrayal.db.rotateRoom
 import com.tylerkindy.betrayal.sendUpdate
 import io.ktor.application.call
 import io.ktor.http.HttpStatusCode
@@ -29,6 +30,16 @@ val roomRoutes: Route.() -> Unit = {
                     ?: return@post call.respond(HttpStatusCode.BadRequest, "Missing gridX or gridY")
 
                 moveRoom(gameId, roomId, loc)
+                call.respond(HttpStatusCode.OK, "")
+                sendUpdate(gameId)
+            }
+
+            post("rotate") {
+                val gameId = call.parameters["gameId"]!!
+                val roomId = call.parameters["roomId"]?.toInt()
+                    ?: return@post call.respond(HttpStatusCode.BadRequest, "Invalid room ID")
+
+                rotateRoom(gameId, roomId)
                 call.respond(HttpStatusCode.OK, "")
                 sendUpdate(gameId)
             }


### PR DESCRIPTION
I keep going back and forth on whether I should associate players and monsters with a room by ID rather than by its coordinates. The current implementation makes things like this movement pretty repetitive and error-prone, but using coordinates keeps things flexible if there's a need to place players or monsters outside the house in a certain haunt.